### PR TITLE
replies: fix message split by new line by error

### DIFF
--- a/riftbot.py
+++ b/riftbot.py
@@ -146,6 +146,9 @@ def get_reply_direct(id):
 def short_reply_content(content):
 	expected_size = 60
 
+	# make linear message instead
+	content = content.replace('\n', ' ')
+
 	# increase expected size if some message format is found
 	# such as pings, emojis, etc
 	#


### PR DESCRIPTION
discord replies replace new line by space, so that was done here too